### PR TITLE
Classify what gates each scenario, and split failure reporting along it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -478,6 +478,35 @@ real catches, so a switch is safe; it is just not worth making, because these
 checks are mostly negatives guarding against invented capabilities and the
 saving is trivial.
 
+**Classify what gates a scenario, and read failures along it.** Every scenario
+carries `gated_by` in its frontmatter: `discovery`, `judgement` or `mixed`. The
+test is one question — **if we improved our docs and skills, could this cell go
+from red to green?** If yes it is `discovery` and a failure is a to-do for us.
+If the agent had everything it needed and chose badly, acting more broadly than
+asked or stopping short, it is `judgement`: no documentation change moves it, so
+it measures the model rather than the product.
+
+This matters because the two are otherwise the same red square with opposite
+implications, and `passed` is the AND of every check — so "could not configure a
+queue" and "configured it and broke something else" are indistinguishable in a
+snapshot. Reporting them as one number invites reading model carefulness as a
+documentation win, or the reverse.
+
+```bash
+pnpm --filter @hookdeck-evals/framework report-results
+```
+
+splits a snapshot along it, and prints the failing check names for `mixed`
+scenarios, where the label alone cannot say which half failed. Run it before
+deciding what to work on from a set of results: on the 78/90 snapshot every one
+of the twelve failures was discovery-gated, which is a different instruction
+from the same twelve split evenly.
+
+Prefer `discovery` when writing new scenarios. A `judgement` scenario is still
+worth publishing as a floor — carefulness on multi-part tickets is a real fact
+about running agents — but it will never move for anything we ship, so a suite
+made of them measures models and calls it a product benchmark.
+
 **Prefer deterministic checks.** Across supabase/evals, 69 of 91 checks are
 deterministic and 22 are judged. A scenario that is entirely judged is a design
 smell.

--- a/apps/framework/package.json
+++ b/apps/framework/package.json
@@ -13,6 +13,7 @@
     "export-results": "node --import tsx/esm scripts/export-results.ts",
     "score-only": "node --env-file=../../.env --import tsx/esm scripts/score-only.ts",
     "compare-snapshots": "node --import tsx/esm scripts/compare-snapshots.ts",
+    "report-results": "node --import tsx/esm scripts/report-results.ts",
     "demo:mcp": "node --env-file=../../.env --import tsx/esm scripts/mcp-demo.ts",
     "demo:executor": "node --env-file=../../.env --import tsx/esm scripts/executor-demo.ts"
   },

--- a/apps/framework/scripts/export-results.ts
+++ b/apps/framework/scripts/export-results.ts
@@ -180,6 +180,7 @@ async function readResultFile(
     product: promptData?.product ?? parsedResult.product,
     topic: promptData?.topic ?? parsedResult.topic,
     suite: promptData?.suite ?? parsedResult.suite,
+    gatedBy: promptData?.gatedBy ?? parsedResult.gatedBy,
     interface: promptData?.interface ?? parsedResult.interface,
     cliVersion: promptData?.cliVersion ?? parsedResult.cliVersion,
     passed: parsedResult.passed === true,

--- a/apps/framework/scripts/report-results.ts
+++ b/apps/framework/scripts/report-results.ts
@@ -1,0 +1,173 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { discoverEvals, EVALS_ROOT } from '../lib/discovery.js';
+
+/**
+ * Read a snapshot and say what kind of failures it contains.
+ *
+ * A pass rate answers "how did the agents do". It does not answer the question
+ * this benchmark exists for, which is **what should we change**. Those come
+ * apart because a red cell has two very different causes:
+ *
+ * - The agent could not find out how. That is ours: a documentation or skills
+ *   gap, and fixing it should turn the cell green in a later run.
+ * - The agent knew how and chose badly — acted more broadly than asked, or
+ *   stopped short. No documentation change moves that, so it is a fact about
+ *   running agents rather than a to-do for us.
+ *
+ * Reported as one number they are indistinguishable, which invites reading
+ * model carefulness as a documentation win, or the reverse. `gated_by` in each
+ * scenario's frontmatter records which kind it is, and this splits the
+ * scoreboard along it.
+ *
+ * For `mixed` scenarios the classification cannot answer it alone, so the
+ * failing check names are printed: they are what says whether the agent could
+ * not do the task or did it and broke something adjacent.
+ *
+ * ```bash
+ * pnpm --filter @hookdeck-evals/framework report-results
+ * pnpm --filter @hookdeck-evals/framework report-results results/runs/2026-08-21.json
+ * ```
+ */
+
+type GatedBy = 'discovery' | 'judgement' | 'mixed';
+
+interface Check {
+  name?: string;
+  passed?: boolean;
+}
+
+interface Row {
+  experiment: string;
+  eval: string;
+  passed: boolean;
+  gatedBy?: GatedBy;
+  suite?: string;
+  checks?: Check[];
+}
+
+interface Snapshot {
+  publishedAt?: string;
+  runId?: string;
+  results: Row[];
+}
+
+const UNCLASSIFIED = 'unclassified';
+
+function load(path: string): Snapshot {
+  const full = path.startsWith('/') ? path : join(EVALS_ROOT, path);
+  if (!existsSync(full)) throw new Error(`no snapshot at ${full}`);
+  return JSON.parse(readFileSync(full, 'utf8'));
+}
+
+function main() {
+  const [path = 'results/latest.json'] = process.argv.slice(2);
+  const snapshot = load(path);
+
+  // Benchmark only. Regression scenarios are meant to pass everywhere, so
+  // folding them in moves the rate without meaning anything.
+  const rows = snapshot.results.filter(
+    (r) => (r.suite ?? 'benchmark') === 'benchmark'
+  );
+  const failures = rows.filter((r) => !r.passed);
+
+  console.log(`${path}${snapshot.runId ? `  run ${snapshot.runId}` : ''}`);
+  console.log(
+    `\n  ${rows.filter((r) => r.passed).length}/${rows.length} benchmark cells passed\n`
+  );
+
+  // Snapshots exported before `gated_by` existed carry no classification, and
+  // the field describes the scenario rather than the run — so fall back to what
+  // the scenario says today. That makes this readable against existing
+  // snapshots instead of only from the next matrix run onwards.
+  //
+  // Announced rather than silent: it means a scenario reclassified later will
+  // re-label an old run, which is fine for deciding what to work on and wrong
+  // for quoting history.
+  const current = currentClassifications();
+  let inferred = 0;
+
+  const groups = new Map<string, Row[]>();
+  for (const row of failures) {
+    let key = row.gatedBy;
+    if (!key && current.has(row.eval)) {
+      key = current.get(row.eval);
+      inferred += 1;
+    }
+    groups.set(key ?? UNCLASSIFIED, [
+      ...(groups.get(key ?? UNCLASSIFIED) ?? []),
+      row,
+    ]);
+  }
+
+  if (inferred > 0) {
+    console.log(
+      `  ${inferred} row(s) carry no classification of their own; using what ` +
+        'the scenario says today. Re-export to record it in the snapshot.\n'
+    );
+  }
+
+  if (failures.length === 0) {
+    console.log('  No failures.');
+    return;
+  }
+
+  report(
+    groups.get('discovery') ?? [],
+    'Discovery — the agent could not find out how',
+    'Ours to fix. A docs or skills change should turn these green in a later run.'
+  );
+
+  report(
+    groups.get('judgement') ?? [],
+    'Judgement — the agent knew how and chose badly',
+    'Not moved by documentation. Publish as a floor; do not read as a docs gap.'
+  );
+
+  // Printed with their failing checks, because the label alone does not say
+  // which half failed and the two have opposite implications.
+  const mixed = groups.get('mixed') ?? [];
+  if (mixed.length > 0) {
+    console.log('\n  Mixed — read the failing check to tell which:');
+    for (const row of mixed) {
+      const failed = (row.checks ?? [])
+        .filter((c) => c.passed === false)
+        .map((c) => c.name ?? '(unnamed)');
+      console.log(`    ${row.eval} x ${row.experiment}`);
+      for (const name of failed) console.log(`        ✗ ${name}`);
+      if (failed.length === 0) {
+        console.log('        (no per-check detail in this snapshot)');
+      }
+    }
+  }
+
+  const unclassified = groups.get(UNCLASSIFIED) ?? [];
+  if (unclassified.length > 0) {
+    console.log(
+      `\n  Unclassified (${unclassified.length}) — no \`gated_by\` in the scenario's frontmatter,` +
+        '\n  so these cannot be read either way. Classify them:'
+    );
+    for (const id of [...new Set(unclassified.map((r) => r.eval))]) {
+      console.log(`    ${id}`);
+    }
+  }
+}
+
+/** What each scenario's frontmatter says right now, by eval id. */
+function currentClassifications(): Map<string, GatedBy> {
+  const map = new Map<string, GatedBy>();
+  for (const ev of discoverEvals()) {
+    const gatedBy = (ev.metadata as { gatedBy?: GatedBy } | undefined)?.gatedBy;
+    if (gatedBy) map.set(ev.id, gatedBy);
+  }
+  return map;
+}
+
+function report(rows: Row[], title: string, note: string) {
+  if (rows.length === 0) return;
+  console.log(`\n  ${title} (${rows.length}):`);
+  for (const row of rows) console.log(`    ${row.eval} x ${row.experiment}`);
+  console.log(`    ${note}`);
+}
+
+main();

--- a/evals/benchmark-alerting-001-delivery-alerts/PROMPT.md
+++ b/evals/benchmark-alerting-001-delivery-alerts/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: benchmark
+gated_by: discovery
 product:
   - event-gateway
 topic:

--- a/evals/benchmark-dedupe-001-duplicate-events/PROMPT.md
+++ b/evals/benchmark-dedupe-001-duplicate-events/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: benchmark
+gated_by: discovery
 product:
   - event-gateway
 topic:

--- a/evals/benchmark-delivery-001-slow-consumer/PROMPT.md
+++ b/evals/benchmark-delivery-001-slow-consumer/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: benchmark
+gated_by: discovery
 product:
   - event-gateway
 topic:

--- a/evals/benchmark-delivery-002-rate-limited-endpoint/PROMPT.md
+++ b/evals/benchmark-delivery-002-rate-limited-endpoint/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: benchmark
+gated_by: discovery
 product:
   - event-gateway
 topic:

--- a/evals/benchmark-filtering-001-enterprise-orders/PROMPT.md
+++ b/evals/benchmark-filtering-001-enterprise-orders/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: benchmark
+gated_by: discovery
 product:
   - event-gateway
 topic:

--- a/evals/benchmark-filtering-002-high-value-retries/PROMPT.md
+++ b/evals/benchmark-filtering-002-high-value-retries/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: benchmark
+gated_by: discovery
 product:
   - event-gateway
 topic:

--- a/evals/benchmark-investigate-001-failing-deliveries/PROMPT.md
+++ b/evals/benchmark-investigate-001-failing-deliveries/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: investigate
 suite: benchmark
+gated_by: mixed
 product:
   - event-gateway
 topic:

--- a/evals/benchmark-investigate-002-partial-outage/PROMPT.md
+++ b/evals/benchmark-investigate-002-partial-outage/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: investigate
 suite: benchmark
+gated_by: mixed
 product:
   - event-gateway
 topic:

--- a/evals/benchmark-localdev-001-listen-locally/PROMPT.md
+++ b/evals/benchmark-localdev-001-listen-locally/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: benchmark
+gated_by: discovery
 product:
   - event-gateway
 topic:

--- a/evals/benchmark-outpost-001-customer-subscriptions/PROMPT.md
+++ b/evals/benchmark-outpost-001-customer-subscriptions/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: benchmark
+gated_by: discovery
 product:
   - outpost
 topic:

--- a/evals/benchmark-outpost-002-disabled-destination/PROMPT.md
+++ b/evals/benchmark-outpost-002-disabled-destination/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: resolve
 suite: benchmark
+gated_by: discovery
 product:
   - outpost
 topic:

--- a/evals/benchmark-outpost-003-operator-events/PROMPT.md
+++ b/evals/benchmark-outpost-003-operator-events/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: benchmark
+gated_by: discovery
 product:
   - outpost
 topic:

--- a/evals/benchmark-resolve-001-paused-connection/PROMPT.md
+++ b/evals/benchmark-resolve-001-paused-connection/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: resolve
 suite: benchmark
+gated_by: discovery
 product:
   - event-gateway
 topic:

--- a/evals/benchmark-resolve-002-scoped-redelivery/PROMPT.md
+++ b/evals/benchmark-resolve-002-scoped-redelivery/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: resolve
 suite: benchmark
+gated_by: mixed
 product:
   - event-gateway
 topic:

--- a/evals/benchmark-transform-001-reshape-payload/PROMPT.md
+++ b/evals/benchmark-transform-001-reshape-payload/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: benchmark
+gated_by: discovery
 product:
   - event-gateway
 topic:

--- a/evals/benchmark-verification-001-stripe-express/PROMPT.md
+++ b/evals/benchmark-verification-001-stripe-express/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: benchmark
+gated_by: discovery
 product:
   - event-gateway
 topic:

--- a/evals/benchmark-verification-002-elevenlabs-callbacks/PROMPT.md
+++ b/evals/benchmark-verification-002-elevenlabs-callbacks/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: benchmark
+gated_by: discovery
 product:
   - event-gateway
 topic:

--- a/evals/regression-filtering-001-regex-capability/PROMPT.md
+++ b/evals/regression-filtering-001-regex-capability/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: regression
+gated_by: discovery
 product:
   - event-gateway
 topic:

--- a/evals/regression-limits-001-oversized-payload/PROMPT.md
+++ b/evals/regression-limits-001-oversized-payload/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: investigate
 suite: regression
+gated_by: discovery
 product:
   - event-gateway
 topic:

--- a/evals/regression-verification-001-generic-hmac/PROMPT.md
+++ b/evals/regression-verification-001-generic-hmac/PROMPT.md
@@ -1,6 +1,7 @@
 ---
 stage: build
 suite: regression
+gated_by: discovery
 product:
   - event-gateway
 topic:

--- a/packages/core/src/eval-metadata.ts
+++ b/packages/core/src/eval-metadata.ts
@@ -49,6 +49,33 @@ export const evalTopicSchema = z.enum([
 export const EVAL_TOPICS = evalTopicSchema.options;
 export type EvalTopic = z.infer<typeof evalTopicSchema>;
 
+/**
+ * What actually decides whether an agent passes this scenario.
+ *
+ * The benchmark's axis is skills, which is to say documentation: every
+ * experiment gets the same CLI and the same API key, so a row differs from its
+ * twin by what the agent could find out and nothing else. That makes the useful
+ * question about any scenario **"if we improved our docs and skills, could this
+ * cell go from red to green?"**
+ *
+ * - `discovery` — yes. The agent fails because it could not find out how, which
+ *   is ours to fix and is what the whole exercise is for.
+ * - `judgement` — no. The agent had everything it needed and chose badly: acted
+ *   more broadly than asked, or stopped short. No documentation change moves
+ *   this, so it measures the model rather than the product.
+ * - `mixed` — the scenario contains both, and a red cell does not say which.
+ *
+ * Recorded because the two are otherwise the same red square while having
+ * opposite implications. A discovery failure is a to-do for us; a judgement
+ * failure is a fact about running agents against any product, worth publishing
+ * as a floor but not something shipping docs will change. Reporting them as one
+ * number invites reading model carefulness as a documentation win, or the
+ * reverse.
+ */
+export const evalGatedBySchema = z.enum(['discovery', 'judgement', 'mixed']);
+export const EVAL_GATED_BY = evalGatedBySchema.options;
+export type EvalGatedBy = z.infer<typeof evalGatedBySchema>;
+
 export const evalSuiteSchema = z.enum(['benchmark', 'regression', 'other']);
 export const EVAL_SUITES = evalSuiteSchema.options;
 export type EvalSuite = z.infer<typeof evalSuiteSchema>;
@@ -115,6 +142,12 @@ export type EvalMetadata = {
   product: EvalProduct[];
   topic: EvalTopic[];
   suite: EvalSuite;
+  /**
+   * What decides pass or fail here — see `evalGatedBySchema`. Optional so
+   * existing scenarios stay valid; unset reads as "not yet classified" rather
+   * than as any particular kind.
+   */
+  gatedBy?: EvalGatedBy;
   interface?: EvalInterface;
   /** Hookdeck CLI version this scenario requires (sandbox evals only). */
   cliVersion?: string;
@@ -176,6 +209,7 @@ export const evalMetadataSchema = z.object({
   product: z.array(evalProductSchema).min(1),
   topic: z.array(evalTopicSchema).min(1),
   suite: evalSuiteSchema,
+  gatedBy: evalGatedBySchema.optional(),
   interface: evalInterfaceSchema.optional(),
   cliVersion: cliVersionSchema.optional(),
   services: z.array(z.string().min(1)).optional(),
@@ -250,6 +284,10 @@ export const evalFrontmatterSchema = z.preprocess((raw) => {
     product: toTokenList(data.product ?? data.products),
     topic: toTokenList(data.topic ?? data.topics),
     suite: toToken(data.suite),
+    // `gated_by` as well as `gatedBy`: the rest of this frontmatter is
+    // snake-case in the files, and a key silently dropped here is validated as
+    // absent rather than rejected — which is how `requires` came to be ignored.
+    gatedBy: toToken(data.gatedBy ?? data.gated_by),
     interface: toToken(data.interface),
     cliVersion: data.cliVersion,
     // `services: []` means database only; an omitted key means the full stack.
@@ -386,6 +424,7 @@ const evalResultShape = {
   product: z.array(evalProductSchema).optional(),
   topic: z.array(evalTopicSchema).optional(),
   suite: evalSuiteSchema.optional(),
+  gatedBy: evalGatedBySchema.optional(),
   interface: evalInterfaceSchema.optional(),
   cliVersion: cliVersionSchema.optional(),
   passed: z.boolean().optional(),


### PR DESCRIPTION
A pass rate says how the agents did. It does not say **what we should change** — and those come apart, because a red cell has two causes with opposite implications:

- The agent **could not find out how**. A docs or skills gap; ours to fix, and fixing it should turn the cell green in a later run.
- The agent **knew how and chose badly** — acted more broadly than asked, or stopped short. No documentation change moves that.

Reported as one number they are indistinguishable. And `passed` is the AND of every check, so "could not configure a queue" and "configured it fine but broke something adjacent" are the same red square.

## What this adds

- `gated_by` in scenario frontmatter: `discovery` | `judgement` | `mixed`
- All twenty scenarios classified
- The field carried through to exported result rows and the published schema
- `pnpm --filter @hookdeck-evals/framework report-results` — splits a snapshot along it

The test for classifying is one question: **if we improved our docs and skills, could this cell go from red to green?**

Seventeen are `discovery`. Three are `mixed` — the two investigate scenarios and scoped-redelivery, where the discriminating check is about not acting more broadly than asked. **None are pure `judgement`**, which is itself worth knowing: we have no scenario measuring carefulness alone.

`mixed` rows print their failing check names, because the label alone cannot say which half failed and that is exactly the distinction being drawn.

## It already says something

Against the published 78/90 snapshot:

```
  Discovery — the agent could not find out how (12):
    ...
    Ours to fix. A docs or skills change should turn these green in a later run.
```

**All twelve failures are discovery-gated.** Every published failure is ours. That is a different instruction from the same twelve split evenly, and it was not visible before.

## On old snapshots

Rows exported before this field carry no classification, and `gated_by` describes the scenario rather than the run — so the report falls back to what the scenario says today, and says that it did. Fine for deciding what to work on; wrong for quoting history, hence the announcement rather than silence.

## Why it matters for what we build next

A `judgement` scenario is still worth publishing as a floor — carefulness on multi-part tickets is a real fact about running agents. But it will never move for anything we ship, so a suite made of them measures models and calls it a product benchmark. New scenarios should prefer `discovery`, and AGENTS.md now says so.

Note: `outpost-004` is on an unmerged branch ([#36](https://github.com/hookdeck/evals/pull/36)) and is `mixed` — its discriminating check is judgement. I will add the field there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nt2Zgjw7STjrnFXYKRRVAA