### PR TITLE
triage: flag an agent that stopped to ask a question

### DIFF
--- a/apps/framework/scripts/triage.ts
+++ b/apps/framework/scripts/triage.ts
@@ -77,6 +77,27 @@ const CAPABILITY_ENV: Record<string, string> = { outpost: 'OUTPOST_API_KEY' };
  */
 const PRODUCT_SKILLS = new Set(['hookdeck', 'event-gateway', 'outpost']);
 
+/**
+ * Phrases an agent uses when it is waiting for a person.
+ *
+ * The benchmark is single-turn, so a question gets no reply and the agent is
+ * scored on whatever state it left — usually nothing. That is not an agent
+ * failing the task; it is an agent checking before it touches a customer's
+ * project, which is the safer behaviour.
+ *
+ * Measured on 25 August across 36 cells: three of twelve failures were this,
+ * and **all three were in the `+skills` arm** while the baseline never once
+ * stopped to ask. Plausibly a mechanism rather than noise — skills tell an
+ * agent to verify its context, and a weaker model follows that literally. It
+ * also inflates whatever the arm's failure count is being used to argue.
+ *
+ * Flagged rather than fixed, because declaring the benchmark autonomous in the
+ * base prompt would change behaviour everywhere and destroy the ability to
+ * measure how often this happens. See hookdeck/evals#57.
+ */
+const ASKED_AND_STOPPED =
+  /\b(confirm that|before I (inspect|proceed|change|touch|go further)|I need you to confirm|once you have (that|the) (secret|key|credential)|please confirm|can you confirm|need confirmation|waiting on (you|your)|let me know (if|whether) (you|I should))\b/i;
+
 /** Phrases an agent uses when it believes it finished. */
 const SUCCESS_CLAIM =
   /\b(everything (is )?(set up|working|verified)|successfully|all set|is now (set up|configured|working)|done!|completed successfully|verified end-to-end)\b/i;
@@ -170,6 +191,15 @@ function flagsFor(row: Row, requiredEnv: string[]): Flag[] {
     }
   }
 
+  if (row.passed === false && ASKED_AND_STOPPED.test(row.agentReport ?? '')) {
+    flags.push({
+      label: 'ASKED AND STOPPED',
+      detail:
+        'ended its turn with a question, and this benchmark has no way to answer — ' +
+        'scored as a failure, but it is not one about capability (#57)',
+    });
+  }
+
   if (row.passed === false && (row.toolCalls?.length ?? 0) === 0) {
     flags.push({ label: 'NO TOOL CALLS', detail: 'scored without acting' });
   }
@@ -239,7 +269,9 @@ function main() {
         ? 0
         : f.some((x) => x.label === 'UNCLEAN EXIT')
           ? 1
-          : 2;
+          : f.some((x) => x.label === 'ASKED AND STOPPED')
+            ? 2
+            : 3;
     return rank(a.flags) - rank(b.flags);
   });
 

--- a/apps/framework/scripts/triage.ts
+++ b/apps/framework/scripts/triage.ts
@@ -85,11 +85,18 @@ const PRODUCT_SKILLS = new Set(['hookdeck', 'event-gateway', 'outpost']);
  * failing the task; it is an agent checking before it touches a customer's
  * project, which is the safer behaviour.
  *
- * Measured on 25 August across 36 cells: three of twelve failures were this,
- * and **all three were in the `+skills` arm** while the baseline never once
- * stopped to ask. Plausibly a mechanism rather than noise — skills tell an
- * agent to verify its context, and a weaker model follows that literally. It
- * also inflates whatever the arm's failure count is being used to argue.
+ * Measured against the stored runs: **four of twelve failures are this**, three
+ * in `+skills` arms and one in a baseline (`outpost-003` on
+ * `claude-code-sonnet-5-no-skills`).
+ *
+ * An earlier version of this comment said all three were `+skills` and that the
+ * baseline never once stopped to ask, which was written from a hand-read of a
+ * subset before the detector existed. The detector disagreed with it on the
+ * first run. Worth leaving in the record, because the claim was doing work: an
+ * effect confined to one arm reads as *caused by* that arm, and this one is
+ * not — a skills-tells-agents-to-verify story is available and the evidence
+ * does not support it. Four cells is still enough to move a delta measured at
+ * two cells in twenty-four, whichever arms they fall in.
  *
  * Flagged rather than fixed, because declaring the benchmark autonomous in the
  * base prompt would change behaviour everywhere and destroy the ability to


### PR DESCRIPTION
The benchmark is single-turn, so an agent that ends its turn with a question gets no reply and is scored on whatever state it left — usually nothing. That is not an agent failing the task; it is an agent checking before it touches a customer's project.

**Five instances across three models and five scenarios**, every one counted as a capability failure.

## The reasoning behind the pause is usually correct

> This key can only access this one project (it's project-scoped, so I can't list others to compare). Since you haven't named a specific org/project, can you confirm this is the right one **before I look for failed events and retry them**?

> Say go-ahead on #2 and I'll apply it immediately; #1 needs to happen in the dashboard since **there's no API for it yet**.

The first worked out that its key is project-scoped and therefore that it *cannot* verify which project it is in, and declined to retry events in a project it was unsure about. The second had derived the right answer including that part of the configuration is dashboard-only — which is the conclusion of [#34](https://github.com/hookdeck/evals/issues/34) — and stopped for approval before changing shared deployment config.

Both were right. Both scored zero.

## Flagged, not fixed

Declaring the benchmark autonomous in the base prompt would remove the failure mode and change behaviour across every scenario — and AGENTS.md already records that adding an instruction can suppress the very failure a scenario exists to catch. It would also destroy the ability to measure how often this happens.

`supabase/evals` has the same single-turn design: no allowed questions, no canned answers, no multi-turn support in its agent driver. Staying comparable matters, because our floor-versus-discrimination reasoning is calibrated against their ratios.

So: make the rate visible in every run, then decide with a number rather than an impression. [#57](https://github.com/hookdeck/evals/issues/57).

## It corrected the issue it came from

I filed #57 saying all three known cases were in the `+skills` arm, and read that as a mechanism — skills tell an agent to verify its context, weak model follows literally. Running the detector over every stored result found two more, **one of them a baseline cell**. The correlation does not hold; my reading was over-fitted to twelve failures on one model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nt2Zgjw7STjrnFXYKRRVAA