### PR TITLE
Record what the do-not-ask instruction bought

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -661,6 +661,19 @@ whether it worked. Nobody else in the survey does both — Clerk instructs witho
 measuring, upstream does neither. See hookdeck/evals#57 for the five answers four
 other benchmarks give.
 
+**Measured, same day, on the four cells that had tripped the detector: it went to
+zero.** Three now pass. The fourth (`verification-002` on the weak model) made 68
+tool calls, stopped cleanly, scored 3/5 and failed on the handler-side signature
+checks — a capability failure on its merits rather than an agent waiting for a
+person. About $3 to find out.
+
+Read that as one measurement and not four: the detector going 4→0 is what the
+instruction targets and is the direct result, while the three flips to passing are
+consistent with it and are *not* evidence of it. These were failing cells re-run
+once with no control arm, and a failing cell that is re-run can flip on its own.
+Claiming the instruction bought three scenarios would be the same mistake as the
+9–0 skills result in Loop 2, at a smaller scale.
+
 **Prefer more attempts to more instruction.** `--runs 3` stops at the first pass,
 so it costs about 1.11× and it removes a stopped run's power to decide a cell
 without touching the prompt at all. It is the cheapest correction available and


### PR DESCRIPTION
Follow-up measurement for #62. Step 3 of the plan: re-run the four cells that had tripped `ASKED_AND_STOPPED` and check whether the instruction changes anything.

## Result

**The detector goes 4 → 0.**

| cell | before | after |
|---|---|---|
| `resolve-002` × `claude-code-sonnet-5` | asked and stopped | **pass** (2/2, 173s, $0.49) |
| `outpost-003` × `claude-code-sonnet-5-no-skills` | asked and stopped | **pass** (4/4, 755s) |
| `transform-001` × `codex-gpt-5.4-mini` | asked and stopped | **pass** (3/3, 171s) |
| `verification-002` × `codex-gpt-5.4-mini` | asked and stopped | fail (3/5, 68 tool calls, clean stop) |

The remaining failure is now a real one. It created the ElevenLabs source, passed the genuine and forged signature checks, and failed the two handler-side Hookdeck signature checks. Its report ends by *offering* further work rather than blocking on a question, which is why the detector does not fire. That is a capability failure on its merits.

Total cost about $3.

## The caveat, which matters more than the number

Read this as **one** measurement, not four.

The detector going 4 → 0 is the direct result, because suppressing that behaviour is exactly what the instruction targets. The three flips to passing are *consistent with* it and are **not evidence of** it — these were failing cells, re-run once, with no control arm, and a failing cell that is re-run can flip on its own.

Claiming the instruction bought three scenarios would be Loop 2's mistake in miniature: a striking number from a single uncontrolled pass. AGENTS.md now says so in as many words.

## Not a loop

This changed our instrument, not the product, the docs or the skills, so it does not go in `LOOPS.md` and it belongs in a release's `Benchmark` section rather than `Shipped`. Noting it explicitly because the shape is loop-like enough to be filed wrongly.

## Publishing is still held

`EVALS_PUBLISH=false` stays until the milestone-2 run lands a snapshot measured end-to-end under the new prompt. Monday's cron and the 1 September full matrix would otherwise publish a mix of treatments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nt2Zgjw7STjrnFXYKRRVAA