### PR TITLE
Record what each published row was measured under

### DIFF
--- a/apps/framework/harness/run-eval.ts
+++ b/apps/framework/harness/run-eval.ts
@@ -50,6 +50,7 @@ import {
   loadExperiments,
   readSessionSeedArgs,
 } from '../lib/discovery.js';
+import { harnessFingerprint, scenarioFingerprint } from '../lib/provenance.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..', '..', '..');
@@ -833,6 +834,13 @@ async function main() {
             // single number back to the job that produced it, which the page
             // claims they can.
             runId: process.env.GITHUB_RUN_ID,
+            // What this row was measured under, so `--merge` can tell a
+            // carried-forward row that is still current from one that is not.
+            // See `lib/provenance.ts` and #60.
+            provenance: {
+              harness: harnessFingerprint(basePromptFor(ev.mode), ROOT),
+              scenario: scenarioFingerprint(ev.dir),
+            },
             ...ev.metadata,
             ...res,
           })

--- a/apps/framework/lib/provenance.ts
+++ b/apps/framework/lib/provenance.ts
@@ -1,0 +1,123 @@
+import { createHash } from 'node:crypto';
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  HOOKDECK_CLI_VERSION,
+  SKILLS_CLI_VERSION,
+} from '@hookdeck-evals/sandbox';
+
+/**
+ * What a published row was measured under, so a stale one can be told apart
+ * from a current one.
+ *
+ * `export-results --merge` carries forward any cell a run did not re-execute.
+ * That earns its place — the `-no-skills` twins refresh monthly and everything
+ * else weekly, so without it a weekly snapshot would have holes. What it lacks
+ * is any notion of a row going *out of date*. On 25 August the published file
+ * held 114 rows across six execution dates spanning thirteen days, 22 of them
+ * from 13 August: measured before the sandbox CLI moved to 2.5.0, before fixed
+ * sleeps were replaced with polling, before several scorer corrections, and
+ * before the base prompt gained "Do not ask clarifying questions". Nothing in
+ * the file said so. See hookdeck/evals#60.
+ *
+ * Two hashes rather than one, following
+ * [vercel-labs/agent-eval](https://github.com/vercel-labs/agent-eval), which
+ * separates a `contentFingerprint` over the eval's own files from a combined
+ * fingerprint over run-affecting config. The split is what makes the report
+ * useful rather than alarming: "this scenario was rewritten" and "the harness
+ * moved under every scenario at once" want different responses, and a single
+ * hash cannot distinguish them.
+ *
+ * Deliberately *not* a correctness gate. Nothing here drops a row on its own —
+ * `--drop-stale` is opt-in and prints what it removed. A snapshot with holes and
+ * a snapshot with silent thirteen-day-old rows are both wrong, and which is less
+ * wrong depends on what the snapshot is for. This makes the choice visible
+ * instead of making it by default.
+ */
+export interface Provenance {
+  /** The harness every scenario shares: base prompt, CLI pin, skills pin. */
+  harness: string;
+  /** The scenario's own files. Changes when its prompt, seed or scorer does. */
+  scenario: string;
+}
+
+const SHORT = 12;
+
+function short(input: string): string {
+  return createHash('sha256').update(input).digest('hex').slice(0, SHORT);
+}
+
+/**
+ * The pinned skills commit.
+ *
+ * Read from git rather than from `.gitmodules`, because the pin is the recorded
+ * commit and not the branch — #26 is open precisely because that pin can move
+ * without anything in the results saying so. Absent outside a git checkout,
+ * which is honest: an unknown pin should not hash to the same value as a known
+ * one, so it contributes a distinct marker rather than an empty string.
+ */
+function skillsPin(root: string): string {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD:submodules/agent-skills'], {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return 'skills-pin-unavailable';
+  }
+}
+
+/**
+ * Everything shared across scenarios that changes what a run measures.
+ *
+ * The base prompt is in here because it is the one string every cell in every
+ * experiment sees, so a word added to it moves every number at once — which is
+ * exactly what happened on 27 August and is why this module exists now rather
+ * than later. The skill *context* is deliberately excluded: that varies by arm
+ * and is the treatment being measured, not a change to the instrument.
+ */
+export function harnessFingerprint(basePrompt: string, root: string): string {
+  return short(
+    [
+      `base-prompt:${basePrompt}`,
+      `hookdeck-cli:${HOOKDECK_CLI_VERSION}`,
+      `skills-cli:${SKILLS_CLI_VERSION}`,
+      `skills-pin:${skillsPin(root)}`,
+    ].join('\n')
+  );
+}
+
+/**
+ * The scenario's own files: prompt, scorer, seed, solution, fixtures.
+ *
+ * Walked rather than listed, so a scenario that grows a `local/` directory or a
+ * `SOLUTION.ts` is covered without anyone remembering to update this. Sorted, so
+ * the hash does not depend on directory order.
+ */
+export function scenarioFingerprint(evalDir: string): string {
+  const parts: string[] = [];
+
+  const walk = (dir: string, prefix: string) => {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir).sort();
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry === 'node_modules' || entry.startsWith('.')) continue;
+      const full = join(dir, entry);
+      const rel = prefix ? `${prefix}/${entry}` : entry;
+      if (statSync(full).isDirectory()) {
+        walk(full, rel);
+        continue;
+      }
+      parts.push(`${rel}:${short(readFileSync(full, 'utf8'))}`);
+    }
+  };
+
+  walk(evalDir, '');
+  return short(parts.join('\n'));
+}

--- a/apps/framework/package.json
+++ b/apps/framework/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "check": "pnpm typecheck && pnpm test:framework",
+    "check": "pnpm typecheck && pnpm test && pnpm test:framework",
+    "test": "vitest run",
     "eval": "node --env-file=../../.env --import tsx/esm harness/run-eval.ts",
     "eval:dry": "node --env-file=../../.env --import tsx/esm harness/run-eval.ts --dry",
     "eval:smoke": "node --env-file=../../.env --import tsx/esm harness/run-eval.ts --smoke",

--- a/apps/framework/scripts/export-results.ts
+++ b/apps/framework/scripts/export-results.ts
@@ -69,6 +69,18 @@ const EVAL_FILTERS = readRepeatedFlag(rawArgs, 'eval');
 const SUITE_FILTERS = readSuiteFilters(rawArgs);
 const EXPERIMENT_SUITE_FILTERS = readExperimentSuiteFilters(rawArgs);
 const MERGE = rawArgs.includes('--merge');
+/**
+ * Drop carried-forward rows measured under a different harness or a different
+ * version of their own scenario, instead of publishing them.
+ *
+ * Opt-in, because a snapshot with holes and a snapshot with silent thirteen-day-
+ * old rows are both wrong and which is less wrong depends on what the snapshot
+ * is for. A release cut to report a measured change wants this on; a weekly
+ * refresh keeping the page populated probably does not. Without it the report
+ * below still prints, so the staleness is visible either way — which is the
+ * actual defect in #60. Nothing was ever *said*.
+ */
+const DROP_STALE = rawArgs.includes('--drop-stale');
 
 const OUTPUT_FLAG = readRepeatedFlag(rawArgs, 'output')[0];
 const outputPath = OUTPUT_FLAG ? resolve(ROOT, OUTPUT_FLAG) : OUTPUT_PATH;
@@ -330,6 +342,99 @@ async function loadEvalResults(): Promise<EvalResult[]> {
   );
 }
 
+interface Provenanced {
+  experiment: string;
+  eval: string;
+  ranAt?: string;
+  provenance?: { harness?: string; scenario?: string };
+}
+
+/**
+ * Which carried-forward rows were measured under something else.
+ *
+ * "Something else" is decided against the rows this run just produced rather
+ * than against the working tree, so the comparison is between two measurements
+ * rather than between a measurement and whatever happens to be checked out. A
+ * scenario is compared only against a fresh row for that same scenario: the
+ * harness moved under everything at once, but `outpost-002` being rewritten says
+ * nothing about `filtering-001`.
+ *
+ * A row with no `provenance` at all predates this field. Those are reported
+ * separately and never counted as current — not knowing what a row was measured
+ * under is the condition this exists to surface, and treating it as fine would
+ * mean every row published before today silently passes.
+ */
+function splitStale<T extends Provenanced>(carried: T[], fresh: T[]) {
+  const harness = fresh.find((r) => r.provenance?.harness)?.provenance?.harness;
+  const scenarios = new Map<string, string>();
+  for (const row of fresh) {
+    if (row.provenance?.scenario)
+      scenarios.set(row.eval, row.provenance.scenario);
+  }
+
+  const current: T[] = [];
+  const stale: Array<{ row: T; why: string }> = [];
+  for (const row of carried) {
+    if (!row.provenance) {
+      stale.push({ row, why: 'no provenance recorded' });
+      continue;
+    }
+    if (harness && row.provenance.harness !== harness) {
+      stale.push({ row, why: 'harness changed' });
+      continue;
+    }
+    const expected = scenarios.get(row.eval);
+    if (expected && row.provenance.scenario !== expected) {
+      stale.push({ row, why: 'scenario changed' });
+      continue;
+    }
+    current.push(row);
+  }
+  return { current, stale };
+}
+
+/** Says what the merge is about to publish that this run did not measure. */
+function reportCarried(
+  carried: Provenanced[],
+  stale: Array<{ row: Provenanced; why: string }>
+) {
+  if (carried.length === 0) return;
+
+  const dates = new Map<string, number>();
+  for (const row of carried) {
+    const day = (row.ranAt ?? 'unknown').slice(0, 10);
+    dates.set(day, (dates.get(day) ?? 0) + 1);
+  }
+  const spread = [...dates]
+    .sort()
+    .map(([day, n]) => `${day} ${n}`)
+    .join(', ');
+  console.log(
+    `\ncarrying ${carried.length} row(s) this run did not measure — by date: ${spread}`
+  );
+
+  if (stale.length === 0) {
+    console.log('  all current: same harness, same scenario files.');
+    return;
+  }
+
+  const byReason = new Map<string, number>();
+  for (const { why } of stale) byReason.set(why, (byReason.get(why) ?? 0) + 1);
+  console.log(
+    `  ${stale.length} measured under something else — ` +
+      [...byReason].map(([why, n]) => `${why}: ${n}`).join(', ')
+  );
+  for (const { row, why } of stale.slice(0, 10)) {
+    console.log(`    ${row.eval} x ${row.experiment}  (${why})`);
+  }
+  if (stale.length > 10) console.log(`    …and ${stale.length - 10} more`);
+  console.log(
+    DROP_STALE
+      ? '  --drop-stale: removing these rather than publishing them.'
+      : '  publishing them anyway. Pass --drop-stale to leave the cells absent instead.'
+  );
+}
+
 async function main() {
   const newResults = await loadEvalResults();
   const hasFilters =
@@ -350,10 +455,14 @@ async function main() {
     const replaced = new Set(
       newResults.map((r) => `${r.experiment}::${r.eval}`)
     );
-    results = [
-      ...existing.filter((r) => !replaced.has(`${r.experiment}::${r.eval}`)),
-      ...newResults,
-    ].sort(
+    const carried = existing.filter(
+      (r) => !replaced.has(`${r.experiment}::${r.eval}`)
+    );
+
+    const { current, stale } = splitStale(carried, newResults);
+    reportCarried(carried, stale);
+
+    results = [...(DROP_STALE ? current : carried), ...newResults].sort(
       (a, b) =>
         a.experiment.localeCompare(b.experiment) || a.eval.localeCompare(b.eval)
     );

--- a/apps/framework/test/provenance.test.ts
+++ b/apps/framework/test/provenance.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { scenarioFingerprint } from '../lib/provenance.js';
+
+/**
+ * The defect these guard against shipped for weeks: `--merge` carried forward
+ * every cell a run did not re-execute, with no notion of a row going out of
+ * date. One published snapshot held rows from six execution dates spanning
+ * thirteen days, measured across a CLI bump, several scorer corrections and a
+ * base-prompt change, and said none of it. See hookdeck/evals#60.
+ */
+
+const dirs: string[] = [];
+
+function scenario(files: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), 'prov-'));
+  dirs.push(dir);
+  for (const [name, content] of Object.entries(files)) {
+    const full = join(dir, name);
+    mkdirSync(join(full, '..'), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return dir;
+}
+
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+describe('scenarioFingerprint', () => {
+  it('is stable for identical content', () => {
+    const a = scenario({ 'EVAL.ts': 'export default 1', 'PROMPT.md': 'do it' });
+    const b = scenario({ 'EVAL.ts': 'export default 1', 'PROMPT.md': 'do it' });
+    expect(scenarioFingerprint(a)).toBe(scenarioFingerprint(b));
+  });
+
+  it('changes when a scorer changes', () => {
+    const before = scenario({ 'EVAL.ts': 'export default 1' });
+    const after = scenario({ 'EVAL.ts': 'export default 2' });
+    expect(scenarioFingerprint(before)).not.toBe(scenarioFingerprint(after));
+  });
+
+  it('changes when a prompt changes', () => {
+    // The case that matters most: a reworded ticket measures a different task,
+    // and every published run of the old wording is describing something else.
+    const before = scenario({ 'EVAL.ts': 'x', 'PROMPT.md': 'stop cancels' });
+    const after = scenario({ 'EVAL.ts': 'x', 'PROMPT.md': 'stop everything' });
+    expect(scenarioFingerprint(before)).not.toBe(scenarioFingerprint(after));
+  });
+
+  it('covers files added later, without being told about them', () => {
+    // Walked rather than listed, so a scenario growing a SOLUTION.ts or a
+    // local/ workspace is covered without anyone remembering to update it.
+    const before = scenario({ 'EVAL.ts': 'x' });
+    const after = scenario({ 'EVAL.ts': 'x', 'local/INFRA.md': 'seeded' });
+    expect(scenarioFingerprint(before)).not.toBe(scenarioFingerprint(after));
+  });
+
+  it('ignores dotfiles and node_modules', () => {
+    // A stray .DS_Store or an installed dependency is not a change to what the
+    // scenario measures, and treating it as one would mark every row stale.
+    const plain = scenario({ 'EVAL.ts': 'x' });
+    const noisy = scenario({
+      'EVAL.ts': 'x',
+      '.DS_Store': 'junk',
+      'node_modules/pkg/index.js': 'whatever',
+    });
+    expect(scenarioFingerprint(plain)).toBe(scenarioFingerprint(noisy));
+  });
+});

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -3,7 +3,13 @@ export type {
   DockerSandboxOptions,
   RunCommandOptions,
 } from './docker-sandbox.js';
-export { ensureSandboxImage, SANDBOX_DOCKERFILE_PATH } from './image.js';
+export {
+  ensureSandboxImage,
+  SANDBOX_DOCKERFILE_PATH,
+  // Exported for provenance: the CLI pin is part of what a published row was
+  // measured under, and a bump changes the product under test. See #60.
+  HOOKDECK_CLI_VERSION,
+} from './image.js';
 export {
   toAgentSandbox,
   resolveSandboxPath,


### PR DESCRIPTION
The stale-rows fix for #60.

## The problem

`export-results --merge` carries forward every cell a run did not re-execute. That earns its place — the `-no-skills` twins refresh monthly, so without it a weekly snapshot would have holes. What it lacked was any notion of a row going **out of date**.

The 25 August snapshot holds 114 rows across **six execution dates spanning thirteen days**, 22 of them from 13 August — measured before the sandbox CLI moved to 2.5.0, before fixed sleeps became polling, before several scorer corrections, and before the base prompt gained "Do not ask clarifying questions" yesterday. Nothing in the file said so.

The `ranAt` field's own comment already described this ("the published grid is not one snapshot… two cells side by side can be a month apart"). It just never acted on it.

## The change

Each row now carries two fingerprints, following [vercel-labs/agent-eval](https://github.com/vercel-labs/agent-eval):

- **`harness`** — the base prompt, the Hookdeck CLI pin, the skills CLI pin, and the skills submodule commit. What every scenario shares.
- **`scenario`** — a walk of the scenario's own files: prompt, scorer, seed, solution, fixtures.

Two rather than one because *"this scenario was rewritten"* and *"the harness moved under everything at once"* want different responses, and a single hash cannot distinguish them.

`--merge` now reports what it is carrying, by execution date, and which rows were measured under something else:

```
carrying 92 row(s) this run did not measure — by date: 2026-08-13 22, 2026-08-17 44, ...
  66 measured under something else — harness changed: 44, no provenance recorded: 22
    benchmark-dedupe-001-duplicate-events x claude-code-sonnet-5-no-skills  (no provenance recorded)
    ...
  publishing them anyway. Pass --drop-stale to leave the cells absent instead.
```

**It still publishes them.** `--drop-stale` is opt-in, because a snapshot with holes and a snapshot with silent thirteen-day-old rows are both wrong, and which is less wrong depends on what the snapshot is for. A release cut to report a measured change wants it on; a weekly refresh keeping the page populated probably does not. The defect in #60 was that nothing was ever *said* — not that stale rows were carried.

Rows predating the field report as "no provenance recorded" and are never counted as current. Not knowing what a row was measured under is the condition this exists to surface.

## A gap found while doing it

**`apps/framework` had test files that no command ran.** It has no `test` script, so `pnpm -r test` skipped it entirely — including `redact.test.ts`, which guards the credential leak that reached a public artifact on the first real run. That test has never been executed by CI.

Added the script. `pnpm -r test` now covers 13 framework tests that previously ran nowhere, and framework `check` runs them too.

## Verification

`pnpm typecheck` clean, `pnpm -r test` green (267 tests, up from 254), `pnpm -r build` clean. Five new tests cover the scenario fingerprint: stable for identical content, changes on scorer and prompt edits, covers files added later without being told about them, ignores dotfiles and `node_modules`.

## Not in this PR

Re-scoring stored trajectories — τ³-bench's approach, and the clean fix — needs #21 (durable transcripts) first. This makes staleness visible; that would make it repairable without re-running an agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nt2Zgjw7STjrnFXYKRRVAA