### PR TITLE
Record what the published score counts, and what checks are for

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -682,6 +682,31 @@ copied is upstream's other route: Vercel and Convex avoid clarifying questions b
 writing prompts as requirement lists, and this repo has measured that adding an
 instruction to build *suppresses the very failure a scenario exists to catch*.
 
+**The published score is scenarios completed, and checks are evidence rather
+than a score.** One row is one scenario — a ticket an agent was given — and its
+`passed` is the AND of every check in it. That is what the harness records, what
+`results/latest.json` publishes, what a release quotes and what the website
+prints. Upstream is the same: supabase/evals computes `passed / results.length`
+and never aggregates checks into a number.
+
+Decided against the alternative on 29 August, after the website briefly shipped
+check-level percentages to give partial credit for partial work. The idea is
+reasonable and it does not survive contact with scorers that short-circuit:
+**a scorer stops as soon as there is nothing left to check, so a run that fails
+at the first hurdle returns `0/1` where a near-miss returns `4/5`.** Failing
+worse becomes cheaper than failing partially, and each agent's denominator ends
+up set by its own failures — 59, 62 and 65 checks across six arms of the same
+nineteen scenarios. On the 25 August snapshot it put the deliberately weaker
+model at 97% against a frontier agent's 95%, where by scenarios they tie at 89%,
+and the page ranked them in that order. Check counts also become weights: they
+run from one to five per scenario, set by how each scorer happens to be written.
+
+Two things follow for scorer authors. A check list is **not** comparable between
+runs of the same scenario, so never compute a rate from it or compare its length
+across cells. And an early return is still the right shape — a scorer that
+cannot find a tenant has nothing to say about delivery — so the fix is at the
+consumer, not here.
+
 **Classify what gates a scenario, and read failures along it.** Every scenario
 carries `gated_by` in its frontmatter: `discovery`, `judgement` or `mixed`. The
 test is one question — **if we improved our docs and skills, could this cell go


### PR DESCRIPTION
A decision record, no behaviour change. This repository owns the definition of the number; the website is a consumer of it, and until now the rule was written down only there.

## What is recorded

**The published score is scenarios completed.** One row is one scenario, and its `passed` is the AND of every check in it — what the harness records, what `results/latest.json` publishes, what a release quotes, and what supabase/evals does (`passed / results.length`, never an aggregate over checks).

**Checks are evidence behind a verdict, not a score.**

## Why, because the alternative was tried

The website briefly shipped check-level percentages, to give partial credit for partial work. Reasonable idea; it collides with how our scorers are written.

**A scorer stops as soon as there is nothing left to check.** A run that fails at the first hurdle returns `0/1`; a near-miss returns `4/5`:

```
benchmark-verification-002-elevenlabs-callbacks
  codex-gpt-5.4-mini-no-skills   failed   checks 0/1
  codex-gpt-5.6                  failed   checks 4/5
```

Failing worse is cheaper than failing partially, and each agent's denominator ends up set by its own failures — 59, 62 and 65 checks across six arms of the same nineteen scenarios. On the 25 August snapshot:

| experiment | scenarios | checks |
|---|---|---|
| claude-code-sonnet-5-no-skills | 17/19 = **89%** | 59/62 = **95%** |
| codex-gpt-5.4-mini-no-skills | 17/19 = **89%** | 57/59 = **97%** |

They tie by scenarios. By checks the deliberately weaker model reads higher, and the published page ranked it above a frontier agent on its default view.

## The part that matters for scorer authors

A check list is **not comparable between runs of the same scenario**, so nothing should compute a rate from it or compare its length across cells.

The early return itself is correct — a scorer that cannot find a tenant has nothing honest to say about delivery — so the fix belonged at the consumer, not here. That is [hookdeck/website#780](https://github.com/hookdeck/website/pull/780).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQzUoMAwEBJWpEGVvVzSjK