### PR TITLE
Codify what a release title names, and the order of the sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,13 +265,22 @@ The parsed format is three sections of one-line items:
 - <title> · #<issue>
 ```
 
-**The title names the product finding or fix**, not the state of our instrument.
+**The title names the product finding or fix**, not the state of our instrument, and
+it is short — the website renders the release name as the heading of its changelog
+card, so eight words is a working ceiling and a wrapped title is the symptom of a
+long one.
 A release note is read by someone building on Hookdeck: what changed for them, or
 what we learned about the product they are using. "The CLI no longer works behind your
 back in a guest project" and "Agents can now authenticate the CLI without a terminal"
 are the pattern. "Outpost coverage goes from one scenario to five" (v0.3.0) is not —
 it titles the release with our own coverage, which is a fact about the benchmark. When
 nothing shipped, title it with the finding.
+
+**The first paragraph is the summary the page renders.** The website takes whole
+sentences from it up to 120 characters and shows them under the title, so it has to
+read as a lede on its own — not a scene-setting sentence that only works with the rest
+of the paragraph behind it. Both halves of the card come from the release; nothing
+about a release is configured in the website.
 
 **Write the notes with the `hookdeck-voice` skill loaded.** They are public,
 Hookdeck-branded content that a blog post or changelog entry links to, and they were

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,22 @@ when there is a measured change to report, not on a schedule.
 commit, so the release points at exactly the data it describes, and
 `results/runs/<timestamp>.json` is the immutable snapshot behind it.
 
+**It is a GitHub release, not a bare tag.** The website reads the releases API, resolves
+the most recent release to its tag, and reads `results/` at that ref — so a tag pushed
+without a release publishes nothing, and the page keeps showing the previous snapshot.
+Cutting one is a single command against the results commit rather than the branch tip:
+
+```bash
+gh release create v0.4.0 --target <results-commit-sha> \
+  --title "<the product finding or fix>" --notes-file <draft>
+```
+
+Lightweight tags, created by that command; nothing here needs an annotated tag or a
+signature. v0.1.0 and v0.2.0 point at their results commits. **v0.3.0 points at the
+merge commit of its release PR**, which happens to carry the same tree and so works,
+but it is not what this paragraph asks for — check `git log -1 <tag>` names a publish
+commit before announcing anything from it.
+
 The notes carry:
 
 - the run: id, date, and a link to the workflow run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,12 +242,31 @@ The parsed format is three sections of one-line items:
 ## Shipped
 - <title> · <where> · #<issue>
 
-## Benchmark
-- <title> · #<issue>
-
 ## Discovered
 - <title> · #<issue>
+
+## Benchmark
+- <title> · #<issue>
 ```
+
+**The title names the product finding or fix**, not the state of our instrument.
+A release note is read by someone building on Hookdeck: what changed for them, or
+what we learned about the product they are using. "The CLI no longer works behind your
+back in a guest project" and "Agents can now authenticate the CLI without a terminal"
+are the pattern. "Outpost coverage goes from one scenario to five" (v0.3.0) is not —
+it titles the release with our own coverage, which is a fact about the benchmark. When
+nothing shipped, title it with the finding.
+
+**Write the notes with the `hookdeck-voice` skill loaded.** They are public,
+Hookdeck-branded content that a blog post or changelog entry links to, and they were
+written three times without it. American English, no hype vocabulary, specific over
+generic, honest about maturity.
+
+**In that order: Shipped, Discovered, Benchmark.** What a reader has a stake in comes
+first — what changed for them, then what we found out about the product — and the
+repairs to our own instrument come last. The website does not group by section, so
+this is the order of the release page itself, which is where anyone following a link
+from a blog post or a changelog entry arrives.
 
 `Shipped` is a change to the product, the docs or the skills. `Benchmark` is a repair
 to our own instrument, and only ones that have shipped. `Discovered` is a **product**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,7 +232,7 @@ Cutting one is a single command against the results commit rather than the branc
 
 ```bash
 gh release create v0.4.0 --target <results-commit-sha> \
-  --title "<the product finding or fix>" --notes-file <draft>
+  --title "<verb + subject>" --notes-file <draft>
 ```
 
 Lightweight tags, created by that command; nothing here needs an annotated tag or a
@@ -251,6 +251,13 @@ The notes carry:
 **The website reads these releases and renders them as a changelog**, so the notes are
 public copy rather than internal shorthand. Write them for someone who has not read
 the issues.
+
+**Nothing about a release is configured in the website.** Its changelog card takes the
+title from the release name and the summary from the first paragraph of the notes.
+That was not true until 2 September: three tags had hand-written titles and blurbs
+hardcoded in the component, so the page and the releases it linked to disagreed, and a
+fourth release would have rendered with no summary at all — see hookdeck/website#789.
+If a card ever looks wrong, the fix belongs in the release, not in the site.
 
 The parsed format is three sections of one-line items:
 
@@ -276,15 +283,17 @@ attempt stuck:
   the area and leaves out whether it was fixed, documented or found, which is the only
   thing a reader wants from a changelog line.
 
-**It names the product finding or fix**, not the state of our instrument, and it is
-short — the website renders the release name as the heading of its changelog card, so
-four or five words is the target and a wrapped title is the symptom of a long one.
-A release note is read by someone building on Hookdeck: what changed for them, or
-what we learned about the product they are using. "The CLI no longer works behind your
-back in a guest project" and "Agents can now authenticate the CLI without a terminal"
-are the pattern. "Outpost coverage goes from one scenario to five" (v0.3.0) is not —
-it titles the release with our own coverage, which is a fact about the benchmark. When
-nothing shipped, title it with the finding.
+**It is short**, because the website renders the release name as the heading of its
+changelog card: four or five words is the target, and a wrapped title is the symptom
+of a long one.
+
+**It says what the release actually did.** A release note is read by someone building
+on Hookdeck, so a product fix or a product finding is the headline when there is one.
+When the release is work on the instrument — v0.4.0, "Fixed how results are scored and
+published" — title it as that. Promoting a finding to the headline of a release that
+fixed nothing invites the reader to look for a fix that is not there, and titling
+instrument work as though it were a product change is the same mistake pointing the
+other way.
 
 **The first paragraph is the summary the page renders.** The website takes whole
 sentences from it up to 120 characters and shows them under the title, so it has to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,10 +265,17 @@ The parsed format is three sections of one-line items:
 - <title> · #<issue>
 ```
 
-**The title names the product finding or fix**, not the state of our instrument, and
-it is short — the website renders the release name as the heading of its changelog
-card, so eight words is a working ceiling and a wrapped title is the symptom of a
-long one.
+**The title is a noun phrase naming the subject, not a sentence making a claim.**
+"CLI guest account creation", "No-terminal CLI auth", "More Outpost coverage
+scenarios". A title that reads as a headline — "Every number now comes from one run",
+"The CLI no longer works behind your back" — is editorial: it argues rather than
+names, and it is the wrong register for a changelog entry someone is scanning.
+v0.1.0 to v0.3.0 were renamed to this form on 2 September; the sentences they carried
+before are what the notes are for.
+
+**It names the product finding or fix**, not the state of our instrument, and it is
+short — the website renders the release name as the heading of its changelog card, so
+four or five words is the target and a wrapped title is the symptom of a long one.
 A release note is read by someone building on Hookdeck: what changed for them, or
 what we learned about the product they are using. "The CLI no longer works behind your
 back in a guest project" and "Agents can now authenticate the CLI without a terminal"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,13 +265,16 @@ The parsed format is three sections of one-line items:
 - <title> · #<issue>
 ```
 
-**The title is a noun phrase naming the subject, not a sentence making a claim.**
-"CLI guest account creation", "No-terminal CLI auth", "More Outpost coverage
-scenarios". A title that reads as a headline — "Every number now comes from one run",
-"The CLI no longer works behind your back" — is editorial: it argues rather than
-names, and it is the wrong register for a changelog entry someone is scanning.
-v0.1.0 to v0.3.0 were renamed to this form on 2 September; the sentences they carried
-before are what the notes are for.
+**The title says what happened to what.** A verb and its subject: "Fixed CLI guest
+account creation", "Documented no-terminal CLI auth", "Expanded Outpost coverage to
+five scenarios". Two failure modes, both made here on 2 September before the third
+attempt stuck:
+
+- *Editorial* — "Every number now comes from one run", "The CLI no longer works behind
+  your back in a guest project". A headline argues; a changelog entry is scanned.
+- *Subject with no verb* — "No-terminal CLI auth", "CLI guest account creation". Names
+  the area and leaves out whether it was fixed, documented or found, which is the only
+  thing a reader wants from a changelog line.
 
 **It names the product finding or fix**, not the state of our instrument, and it is
 short — the website renders the release name as the heading of its changelog card, so


### PR DESCRIPTION
Three corrections to how release notes get written, all found while drafting v0.4.0.

**The title names the product finding or fix.** A release note is read by someone building on Hookdeck. Two of the three releases follow that — *"The CLI no longer works behind your back in a guest project"*, *"Agents can now authenticate the CLI without a terminal"*. **v0.3.0 does not**: *"Outpost coverage goes from one scenario to five"* titles the release with our own coverage, which is a fact about the benchmark. When nothing shipped, the finding is the title.

**Sections run Shipped, Discovered, Benchmark.** What a reader has a stake in first; repairs to our instrument last. The website does not group by section, so this is the order of the release page itself — where anyone following a link from a blog post arrives.

**Write the notes with the `hookdeck-voice` skill loaded.** They are public, Hookdeck-branded content and three sets were written without it.

## Note on the classification rule

It was already here, and correct: `Discovered` is a **product** finding, and an open defect in our own instrument goes in neither section. I still misapplied it twice while drafting v0.4.0 — three instrument findings under Discovered, then two open instrument defects moved into Benchmark, which the same paragraph forbids. Putting the sections in reading order sets the rule beside the decision instead of four paragraphs below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQzUoMAwEBJWpEGVvVzSjK