### PR TITLE
Let the publish job push when the branch has moved, and commit the counter

### DIFF
--- a/.github/workflows/eval-refresh.yml
+++ b/.github/workflows/eval-refresh.yml
@@ -476,6 +476,16 @@ jobs:
           # skills/ symlinks into the agent-skills submodule; without it a
           # skills experiment installs nothing and silently scores as baseline.
           submodules: recursive
+          # Full history, because the commit step below may have to rebase onto
+          # a branch that moved while the matrix ran — and did, on 1 September.
+          # A shallow clone has no merge base with `origin/main`, so
+          # `git rebase` fails and the retry loop exhausts its attempts with
+          # nothing it can do. That run published nothing and, worse, is red on
+          # a page that links to it as evidence: 115 of its 116 jobs succeeded
+          # and the failure was this step. Re-running it cannot fix that,
+          # because a re-run checks out the original commit and the original
+          # workflow file, so the fix only protects the runs after it.
+          fetch-depth: 0
 
       - name: Install pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
@@ -585,7 +595,12 @@ jobs:
           # The published contract and its history. Staged explicitly rather
           # than with `git add -A`, so a stray file a run happens to leave in
           # the working tree cannot ride along into a published commit.
-          git add results/latest.json results/index.json results/runs
+          # `totals.json` too: `publish-snapshot` writes it — it is the "runs
+          # recorded" counter the page shows — and it was never staged here, so
+          # every CI publish left it at whatever the last hand-publish had
+          # written. Found on 2 September, when a hand-publish moved it from 222
+          # to 348 and nothing in CI ever would have.
+          git add results/latest.json results/index.json results/totals.json results/runs
 
           if git diff --cached --quiet; then
             echo "No eval result changes to commit"


### PR DESCRIPTION
Two defects, both surfaced by the blog agent noticing that the run `/evals` links to renders as **failed**.

115 of that run's 116 jobs succeeded. The one that failed is `publish-results`, and it failed *after* every eval had been measured — so the numbers are sound and the red mark is about how the file got committed.

## 1. The publish job cannot recover from a moved branch

Its checkout is shallow. A matrix takes six hours, `main` moves while it runs, the push is rejected as a non-fast-forward — and the retry loop's `git rebase origin/main` has no merge base in a shallow clone, so all three attempts fail. `fetch-depth: 0` fixes it.

**This cannot repair the run that found it.** Re-running a job checks out the original commit *and the original workflow file*, so the fix protects the runs after it and nothing else. Making that specific run green would mean re-running the matrix (~$100) or publishing a snapshot that carries rows forward to manufacture a green tick, which is the thing #66 exists to prevent.

## 2. The "runs recorded" counter was never committed by CI

`publish-snapshot` writes `results/totals.json`, and the page reads it for the counter under the changelog heading. The commit step stages `latest.json`, `index.json` and `runs/` — **not `totals.json`**. So every CI publish left the counter at whatever a hand-publish had last written. It moved 222 → 348 today by hand; nothing in CI would ever have moved it.

Refs #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQzUoMAwEBJWpEGVvVzSjK